### PR TITLE
Add simple_calender gem to gemfile and dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ ruby '2.5.3'
 gem 'figaro'
 gem 'faraday'
 gem 'rspotify'
+gem "simple_calendar", "~> 2.4"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,8 @@ GEM
       tilt (>= 1.1, < 3)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
+    simple_calendar (2.4.2)
+      rails (>= 3.0)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -280,6 +282,7 @@ DEPENDENCIES
   rspotify
   sass-rails (~> 5.0)
   shoulda-matchers (~> 4.0)
+  simple_calendar (~> 2.4)
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -17,10 +17,12 @@
   <% end %>
 </section>
 
+<section class="calender">
+  <%= month_calendar do |date| %>
+    <%= date %>
+  <% end %>
+</section>
+
 <footer class="logout">
   <%= link_to "Logout", logout_path, method: :delete %>
 </footer>
-
-
-
-


### PR DESCRIPTION
Ryan
**What this PR does**
 - Adds gem called simple_calender
 - This gem will create a very simple calender on your view


* [x] Merge the target branch into the PR branch. Fix any conflicts that might appear.

### New Feature Submissions:

* [x] New feature
* [ ] Bug fix

### Check the correct boxes

* [x] This broke nothing
* [ ] This broke something

### Testing:

* [ ] Wrote new tests
* [ ] Successfully ran tests
* [ ] All new and existing tests passed
* [ ] Ran `rubocop` and fixed offenses

### Checklist:

* [x] My code has no unused/commented out code
* [x] I have reviewed my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have fully tested my code

--------------------------------------------------------------------------------
**Test coverage** (final goal of 100%)

* [x] 90-99%
* [ ] 100%
