### PR TITLE
Fix lovers index controller to set current_user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,6 @@ class ApplicationController < ActionController::Base
   helper_method :current_user
 
   def current_user
-    # binding.pry
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
 end

--- a/app/controllers/lovers_controller.rb
+++ b/app/controllers/lovers_controller.rb
@@ -1,18 +1,15 @@
 class LoversController < ApplicationController
-
+before_action :current_user
+  
   def index
-    @user = User.find_by(id: session[:user_id])
-    if @user.nil?
-      redirect_to root_url, alert: "You must login with Spotify first"
+    @events = CouplisticFacade.get_events(session[:user_id])
+    @songs_n_artists = SpotifyGemFacade.get_recommendations
+    if params[:q]
+      @weather_windows = CouplisticFacade.get_weather_windows(params[:q])
     else
-      @events = CouplisticFacade.get_events(session[:user_id])
-      @songs_n_artists = SpotifyGemFacade.get_recommendations
-      if params[:q]
-        @weather_windows = CouplisticFacade.get_weather_windows(params[:q])
-      else
-        @weather_windows = CouplisticFacade.get_weather_windows("Paris")
-      end
+      @weather_windows = CouplisticFacade.get_weather_windows("Paris")
+    end
 
-      render 'dashboard/index'
+    render 'dashboard/index'
   end
 end


### PR DESCRIPTION
## All Submissions: Ryan
 - Use set current user before_action for authentication on lovers controller

Resolves #

* [x] Merge the target branch into the PR branch. Fix any conflicts that might appear.

### New Feature Submissions:

* [ ] New feature
* [x] Bug fix

### Check the correct boxes

* [x] This broke nothing
* [ ] This broke something

### Testing:

* [ ] Wrote new tests
* [ ] Successfully ran tests
* [ ] All new and existing tests passed
* [ ] Ran `rubocop` and fixed offenses

### Checklist:

* [ ] My code has no unused/commented out code
* [ ] I have reviewed my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have fully tested my code

--------------------------------------------------------------------------------
**Test coverage** (final goal of 100%)

* [ ] 90-99%
* [ ] 100%
